### PR TITLE
fix: updated number regex

### DIFF
--- a/gleam.js
+++ b/gleam.js
@@ -32,6 +32,6 @@ Prism.languages.gleam = {
 	},
 	punctuation: /[.\\:,{}()]/,
 	number:
-		/\b(?:0[bB][01_]+|0[oO][0-7_]+|\d[\d_]*(\\.[\d_]*(e-?[\d_]+))?|0[xX][\da-fA-F_]+)\b/,
+		/\b(?:0[bB][01_]+|0[oO][0-7_]+|\d[\d_]*(\\.[\d_]*(e-?[\d_]+)?)?|0[xX][\da-fA-F_]+)\b/,
 	boolean: /\b(?:True|False|Ok|Error|Nil)\b/,
 };

--- a/gleam.js
+++ b/gleam.js
@@ -32,6 +32,6 @@ Prism.languages.gleam = {
 	},
 	punctuation: /[.\\:,{}()]/,
 	number:
-		/\b(?:0[bB][01_]+|0[oO][0-7_]+|\d[\d_]*(\\.[\d_]*?(e-?[\d_]+))?|0[xX][\da-fA-F_]+)\b/,
+		/\b(?:0[bB][01_]+|0[oO][0-7_]+|\d[\d_]*(\\.[\d_]*(e-?[\d_]+))?|0[xX][\da-fA-F_]+)\b/,
 	boolean: /\b(?:True|False|Ok|Error|Nil)\b/,
 };

--- a/gleam.js
+++ b/gleam.js
@@ -32,6 +32,6 @@ Prism.languages.gleam = {
 	},
 	punctuation: /[.\\:,{}()]/,
 	number:
-		/\b(?:0b[0-1]+|0o[0-7]+|[[:digit:]][[:digit:]_]*(\\.[[:digit:]]*)?|0x[[:xdigit:]]+)\b/,
+		/\b(?:0[bB][01_]+|0[oO][0-7_]+|\d[\d_]*(\\.[\d_]*?(e-?[\d_]+))?|0[xX][\da-fA-F_]+)\b/,
 	boolean: /\b(?:True|False|Ok|Error|Nil)\b/,
 };


### PR DESCRIPTION
Hey, small changes to the number regex:

- Allow `_` in all formats (e.g. `0b1100_0011`)
- Support scientific notation (e.g. `6.02e23`)
- Replaced `[:x?digit:]` notation with `\d` because it's PCRE syntax, not ES syntax
- Allow uppercase radix prefix ([source](https://github.com/gleam-lang/gleam/blob/8743158ef7ac8c8bebd045fadb4f4775a0e7cc8d/compiler-core/src/parse/lexer.rs#L507))

Thanks!