### PR TITLE
Correct module highlighting

### DIFF
--- a/gleam.js
+++ b/gleam.js
@@ -24,7 +24,7 @@ Prism.languages.gleam = {
 		greedy: true,
 	},
 	module: {
-		pattern: /([a-z][a-z0-9_]*)\./,
+		pattern: /([a-z][a-z0-9_]*)\.(?!{)/,
 		inside: {
 			punctuation: /\./,
 		},


### PR DESCRIPTION
This would previously match the last segment of imports like so

```gleam
import bibble/wibble.{wobble}
```